### PR TITLE
do not use http_proxy environment for Net::HTTP (default from ruby 2.0)

### DIFF
--- a/lib/splunk_client/splunk_client.rb
+++ b/lib/splunk_client/splunk_client.rb
@@ -80,7 +80,7 @@ class SplunkClient
     if @PROXY_URI
       http = Net::HTTP.new(@HOST, @PORT, @PROXY_URI.host, @PROXY_URI.port)
     else
-      http = Net::HTTP.new(@HOST, @PORT)
+      http = Net::HTTP.new(@HOST, @PORT, nil)
     end
     http.read_timeout = @READ_TIMEOUT
     http.use_ssl = @SSL


### PR DESCRIPTION
http://ruby-doc.org/stdlib-2.0.0/libdoc/net/http/rdoc/Net/HTTP.html#method-c-new

starting from ruby 2.0 Net::HTTP.new('host', 'port') checks for http_proxy ENV and automatically uses the proxy if so.

this patch creates Net::HTTP with no proxy if it is not passed into SplunkClient.new 
